### PR TITLE
feat: move CRM to sqlite with diff previews

### DIFF
--- a/agents/crm_agent.py
+++ b/agents/crm_agent.py
@@ -1,35 +1,35 @@
-"""
-CRM Agent - Handles client data management using markdown files
-"""
+"""CRM Agent - Handles client data management using a SQLite database."""
 
 from crewai import Agent
-from tools.markdown_tools import (
-    MarkdownReader,
-    SafeMarkdownWriter,
-    ClientParser
-)
+
 from config import get_llm
+from tools.crm_db_tools import (
+    CRMClientApplyUpdate,
+    CRMClientDiffPreview,
+    CRMClientListMarkdownExporter,
+    CRMClientReader,
+)
 
-def crm_agent(clients_file="data/clients.md"):
+
+def crm_agent(db_path: str = "data/clients.db"):
     return Agent(
-        role='CRM Manager',
-        goal='Manage client information efficiently and accurately',
-        backstory=f"""You are an experienced CRM specialist who excels at
-        organizing client data. You can handle inconsistent data formats,
-        extract relevant information, and maintain a clean client database.
-        You're particularly skilled at parsing markdown files and understanding
-        various data input formats.
-
-        The client data is stored in a markdown file located at: {clients_file}
-        You must use this file path when you need to read or write client data.""",
+        role="CRM Manager",
+        goal="Manage client information efficiently and accurately",
+        backstory=(
+            "You are an experienced CRM specialist who keeps the official client "
+            "records inside a local SQLite database. You can parse legacy "
+            "markdown data, surface a diff preview for any change, and ensure "
+            "approved updates are exported as readable markdown snapshots."
+        ),
         tools=[
-            MarkdownReader(),
-            SafeMarkdownWriter(),
-            ClientParser()
+            CRMClientReader(db_path=db_path),
+            CRMClientDiffPreview(db_path=db_path),
+            CRMClientApplyUpdate(db_path=db_path),
+            CRMClientListMarkdownExporter(db_path=db_path),
         ],
         llm=get_llm(),
         verbose=True,
         allow_delegation=False,
         max_iter=3,
-        memory=True
+        memory=True,
     )

--- a/example_usage.py
+++ b/example_usage.py
@@ -133,7 +133,7 @@ def run_full_demo():
     # Initialize the crew
     print("\nInitializing Business Automation Crew...")
     crew = BusinessAutomationCrew(
-        clients_file="data/clients.md",
+        clients_db="data/clients.db",
         pricing_file="data/pricing.md",
         schedule_pdf="data/schedule.pdf",  # You'll need to provide this
         invoice_template="templates/invoice_template.md"
@@ -166,7 +166,7 @@ def interactive_mode():
     print("="*60)
     
     crew = BusinessAutomationCrew(
-        clients_file="data/clients.md",
+        clients_db="data/clients.db",
         pricing_file="data/pricing.md",
         schedule_pdf="data/schedule.pdf",
         invoice_template="templates/invoice_template.md"

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from orchestrator import PlanningOrchestrator
 
 class FlexibleBusinessChat:
     def __init__(self,
-                 clients_file="data/clients.md",
+                 clients_db="data/clients.db",
                  pricing_file="data/pricing.md",
                  schedule_pdf="data/sample_schedule.pdf",
                  invoice_template="templates/invoice_template.md"):
@@ -24,14 +24,14 @@ class FlexibleBusinessChat:
         Initialize the ultra-flexible chat system
         """
         self.context = {
-            'clients_file': clients_file,
+            'clients_db': clients_db,
             'pricing_file': pricing_file,
             'schedule_pdf': schedule_pdf,
             'invoice_template': invoice_template
         }
 
         # Initialize agents
-        self.crm = crm_agent(clients_file=self.context['clients_file'])
+        self.crm = crm_agent(db_path=self.context['clients_db'])
         self.scheduler = scheduler_agent(schedule_pdf=self.context.get('schedule_pdf'))
         self.invoicer = invoice_agent()
         self._crew_cls = Crew
@@ -54,7 +54,7 @@ class FlexibleBusinessChat:
             goal='Understand and fulfill any business-related request by creatively using available agents and tools',
             backstory=f"""You are an intelligent orchestrator with access to three specialized teams:
 
-            1. CRM Team: Manages ALL client-related data. They have access to {self.context['clients_file']}.
+            1. CRM Team: Manages ALL client-related data. They have access to {self.context['clients_db']}.
                They can search, add, update, analyze, and create reports about clients.
 
             2. Scheduling Team: Handles ALL time-related tasks. They work with {self.context.get('schedule_pdf', 'schedule PDFs')}.

--- a/tasks/crm_tasks.py
+++ b/tasks/crm_tasks.py
@@ -1,34 +1,34 @@
-"""
-CRM Tasks - Define specific tasks for client management
-"""
+"""CRM Tasks - Define specific tasks for SQLite-backed client management."""
 
 from crewai import Task
 
-def search_client_task(agent, client_name, clients_file):
-    """Task to search for client contact details"""
+
+def search_client_task(agent, client_name: str, db_path: str):
+    """Task to search for client contact details."""
+
     return Task(
         description=f"""
         Search for the client named '{client_name}' in the CRM database.
-        
+
         Steps:
-        1. Read the markdown file at {clients_file}
-        2. Parse the client information with flexible format handling
-        3. Find the specific client (case-insensitive search)
-        4. Extract and return their contact details including:
+        1. Use the CRM Client Reader tool pointed at {db_path}.
+        2. Request the specific client (case-insensitive lookup).
+        3. Return their structured details, including:
            - Full name
            - Parent/Guardian name
            - Phone number
            - Email address
-        5. Handle any inconsistent data formats gracefully
-        
-        If the client is not found, provide a clear message.
+           - Notes summary if present
+        4. If the client is not found, provide a clear message.
         """,
         agent=agent,
-        expected_output="Client contact details or 'not found' message"
+        expected_output="Client contact details or 'not found' message",
     )
 
-def add_client_task(agent, client_info, clients_file):
-    """Task to add a new client to the CRM"""
+
+def add_client_task(agent, client_info: dict, db_path: str):
+    """Task to add a new client to the CRM."""
+
     return Task(
         description=f"""
         Add a new client to the CRM database with the following information:
@@ -36,82 +36,73 @@ def add_client_task(agent, client_info, clients_file):
         - Parent: {client_info.get('parent')}
         - Phone: {client_info.get('phone')}
         - Email: {client_info.get('email')}
-        
+        - Notes (optional): {client_info.get('notes')}
+
         Steps:
-        1. Read the existing markdown file at {clients_file}
-        2. Check if the client already exists (avoid duplicates)
-        3. Format the new client information properly
-        4. Append the new client to the markdown file
-        5. Maintain consistent formatting with existing entries
-        6. Confirm successful addition
-        
-        Handle missing or incomplete information appropriately.
+        1. Run a diff preview for the proposed record using the CRM Client Diff Preview tool.
+        2. Share the resulting diff with the user for approval.
+        3. After explicit approval, call CRM Client Apply Update with the same payload.
+        4. Confirm that the markdown snapshot was exported successfully.
         """,
         agent=agent,
-        expected_output="Confirmation of client addition or error message"
+        expected_output="Diff preview followed by confirmation of client addition once approved.",
     )
 
-def query_parent_task(agent, client_name, clients_file):
-    """Task to query parent name based on client name"""
+
+def query_parent_task(agent, client_name: str, db_path: str):
+    """Task to query parent name based on client name."""
+
     return Task(
         description=f"""
         Find the parent/guardian name for the client '{client_name}'.
-        
+
         Steps:
-        1. Read the markdown file at {clients_file}
-        2. Parse all client information
-        3. Search for the specific client (case-insensitive)
-        4. Extract and return the parent/guardian name
-        5. If multiple matches exist, list all possibilities
-        
-        Handle various formats like:
-        - "Parent - John Doe"
-        - "Guardian: Jane Smith"
-        - "Parent/Guardian - Mike Johnson"
+        1. Use the CRM Client Reader to fetch the specific client from {db_path}.
+        2. Extract the parent/guardian information.
+        3. If multiple matches exist, list all possibilities and highlight differences.
+        4. Present the findings clearly for the user.
         """,
         agent=agent,
-        expected_output="Parent/guardian name or 'not found' message"
+        expected_output="Parent/guardian name or 'not found' message",
     )
 
-def update_client_task(agent, client_name, updates, clients_file):
-    """Task to update existing client information"""
+
+def update_client_task(agent, client_name: str, updates: dict, db_path: str):
+    """Task to update existing client information."""
+
     return Task(
         description=f"""
         Update the information for client '{client_name}' with the following changes:
         {updates}
-        
+
         Steps:
-        1. Read the markdown file at {clients_file}
-        2. Find the specific client entry
-        3. Update the specified fields while preserving other information
-        4. Rewrite the file with updated information
-        5. Maintain markdown formatting consistency
-        6. Confirm successful update
-        
-        Ensure data integrity and handle errors gracefully.
+        1. Use the CRM Client Diff Preview tool to generate a unified diff of the proposed update.
+        2. Share the diff with the user and wait for confirmation before making changes.
+        3. Once approved, call CRM Client Apply Update with the exact payload.
+        4. Confirm that the markdown export has been refreshed for the client.
+        5. Report the final state back to the user.
         """,
         agent=agent,
-        expected_output="Confirmation of update or error message"
+        expected_output="Diff preview and confirmation of update once approved",
     )
 
-def list_all_clients_task(agent, clients_file):
-    """Task to list all clients in the database"""
+
+def list_all_clients_task(agent, db_path: str):
+    """Task to list all clients in the database."""
+
     return Task(
         description=f"""
         List all clients currently in the CRM database.
-        
+
         Steps:
-        1. Read the markdown file at {clients_file}
-        2. Parse all client entries
-        3. Create a summary list with key information for each client:
+        1. Use the CRM Client Reader tool (without a specific name) targeting {db_path}.
+        2. Summarize key information for each client:
            - Name
            - Parent (if available)
            - Contact status (has phone/email)
-        4. Format the list clearly
-        5. Include a total count of clients
-        
-        Handle any formatting inconsistencies in the source file.
+        3. Mention how to locate the generated markdown snapshots for human review.
+        4. Provide the total count of clients.
         """,
         agent=agent,
-        expected_output="Formatted list of all clients with summary information"
+        expected_output="Formatted list of all clients with summary information",
     )

--- a/tasks/dynamic_tasks.py
+++ b/tasks/dynamic_tasks.py
@@ -17,8 +17,8 @@ def create_dynamic_task(agent, user_request, context=None):
     # Build context string
     context_str = ""
     if context:
-        if context.get('clients_file'):
-            context_str += f"\nClients database location: {context['clients_file']}"
+        if context.get('clients_db'):
+            context_str += f"\nClients database location: {context['clients_db']}"
         if context.get('pricing_file'):
             context_str += f"\nPricing information location: {context['pricing_file']}"
         if context.get('schedule_pdf'):
@@ -75,7 +75,7 @@ def create_dispatcher_task(dispatcher, user_request, available_agents, context=N
     if context:
         context_str = f"""
         Available resources:
-        - Clients database: {context.get('clients_file', 'Not set')}
+        - Clients database: {context.get('clients_db', 'Not set')}
         - Pricing information: {context.get('pricing_file', 'Not set')}
         - Schedule PDF: {context.get('schedule_pdf', 'Not set')}
         - Invoice template: {context.get('invoice_template', 'Not set')}

--- a/tools/crm_db_tools.py
+++ b/tools/crm_db_tools.py
@@ -234,7 +234,7 @@ class CRMClientDiffPreview(BaseTool):
             difflib.unified_diff(
                 old_markdown.splitlines(),
                 new_markdown.splitlines(),
-                fromfile="current.md" if existing else "(new client)",
+                fromfile="current.md" if baseline else "(new client)",
                 tofile="proposed.md",
                 lineterm="",
             )

--- a/tools/crm_db_tools.py
+++ b/tools/crm_db_tools.py
@@ -1,0 +1,384 @@
+"""CRM database tools providing SQLite-backed storage with markdown exports."""
+
+from __future__ import annotations
+
+import difflib
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from crewai.tools import BaseTool
+
+
+DEFAULT_DB_PATH = Path("data/clients.db")
+DEFAULT_EXPORT_DIR = Path("exports/clients")
+LEGACY_MARKDOWN_PATH = Path("data/clients.md")
+
+
+def _ensure_directories(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _slugify(value: str) -> str:
+    """Return a filesystem-safe slug for the provided value."""
+
+    safe = [c.lower() if c.isalnum() else "-" for c in value.strip()]
+    slug = "".join(safe)
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    return slug.strip("-") or "client"
+
+
+def _render_markdown(client: Dict[str, Any]) -> str:
+    """Render a markdown snapshot for a client record."""
+
+    lines = [
+        f"# Client: {client['name']}",
+        f"- Parent: {client.get('parent') or 'Not specified'}",
+        f"- Phone: {client.get('phone') or 'Not specified'}",
+        f"- Email: {client.get('email') or 'Not specified'}",
+    ]
+
+    notes = client.get("notes")
+    if notes:
+        lines.extend(["", "## Notes"])
+        for note_line in notes.splitlines():
+            if note_line.strip():
+                lines.append(f"- {note_line.strip()}")
+
+    return "\n".join(lines).strip() + "\n"
+
+
+def _dict_from_row(row: sqlite3.Row) -> Dict[str, Any]:
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "parent": row["parent"],
+        "phone": row["phone"],
+        "email": row["email"],
+        "notes": row["notes"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def _normalize_notes(value: Any) -> Optional[str]:
+    """Convert arbitrary note payloads to a normalized string."""
+
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, (list, tuple, set)):
+        lines = [str(item).strip() for item in value if str(item).strip()]
+        return "\n".join(lines) or None
+    return str(value)
+
+
+def _initialise_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS clients (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL,
+            parent TEXT,
+            phone TEXT,
+            email TEXT,
+            notes TEXT,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+
+def _maybe_import_legacy_markdown(conn: sqlite3.Connection) -> None:
+    """Populate the database from the legacy markdown file if available."""
+
+    if not LEGACY_MARKDOWN_PATH.exists():
+        return
+
+    cursor = conn.execute("SELECT COUNT(1) FROM clients")
+    (count,) = cursor.fetchone()
+    if count:
+        return
+
+    try:
+        from tools.markdown_tools import ClientParser
+    except Exception:
+        return
+
+    content = LEGACY_MARKDOWN_PATH.read_text(encoding="utf-8")
+    parser = ClientParser()
+    clients = parser._run(content=content)  # type: ignore[attr-defined]
+
+    for client in clients.values():
+        notes = "\n".join(client.get("raw_data", [])) if client.get("raw_data") else None
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO clients (name, parent, phone, email, notes)
+            VALUES (:name, :parent, :phone, :email, :notes)
+            """,
+            {
+                "name": client.get("name") or "Unknown",
+                "parent": client.get("parent"),
+                "phone": client.get("phone"),
+                "email": client.get("email"),
+                "notes": notes,
+            },
+        )
+
+
+@dataclass(slots=True)
+class _CRMContext:
+    """Shared helpers for CRM tools."""
+
+    db_path: Path = DEFAULT_DB_PATH
+    export_dir: Path = DEFAULT_EXPORT_DIR
+
+    def connection(self) -> sqlite3.Connection:
+        _ensure_directories(self.db_path)
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        _initialise_schema(conn)
+        _maybe_import_legacy_markdown(conn)
+        return conn
+
+    def export_markdown(self, client: Dict[str, Any]) -> Path:
+        """Write the client's markdown snapshot to disk."""
+
+        export_dir = self.export_dir
+        export_dir.mkdir(parents=True, exist_ok=True)
+        filename = f"{_slugify(client['name']) or 'client'}.md"
+        export_path = export_dir / filename
+        export_path.write_text(_render_markdown(client), encoding="utf-8")
+        return export_path
+
+
+class CRMClientReader(BaseTool):
+    """Read clients from the SQLite database."""
+
+    name: str = "CRM Client Reader"
+    description: str = (
+        "Read client records from the local SQLite CRM database. "
+        "Provide an optional 'name' parameter for case-insensitive lookup."
+    )
+
+    def __init__(
+        self,
+        db_path: Path | str = DEFAULT_DB_PATH,
+    ) -> None:
+        super().__init__()
+        self._context = _CRMContext(Path(db_path))
+
+    def _run(self, name: Optional[str] = None) -> str:
+        with self._context.connection() as conn:
+            if name:
+                row = conn.execute(
+                    "SELECT * FROM clients WHERE lower(name) = lower(?)",
+                    (name,),
+                ).fetchone()
+                if not row:
+                    return json.dumps({"error": f"Client '{name}' not found"})
+                return json.dumps(_dict_from_row(row), ensure_ascii=False, indent=2)
+
+            rows = conn.execute("SELECT * FROM clients ORDER BY name COLLATE NOCASE").fetchall()
+            clients = [_dict_from_row(row) for row in rows]
+            return json.dumps(clients, ensure_ascii=False, indent=2)
+
+
+class CRMClientDiffPreview(BaseTool):
+    """Generate a diff preview for a proposed client upsert."""
+
+    name: str = "CRM Client Diff Preview"
+    description: str = (
+        "Preview changes to a client's record without applying them. "
+        "Provide a 'client' dictionary containing at least the client name, and "
+        "optional fields to update (parent, phone, email, notes)."
+    )
+
+    def __init__(
+        self,
+        db_path: Path | str = DEFAULT_DB_PATH,
+    ) -> None:
+        super().__init__()
+        self._context = _CRMContext(Path(db_path))
+
+    def _run(self, client: Dict[str, Any]) -> str:
+        if not isinstance(client, dict):
+            return "Error: 'client' payload must be a dictionary."
+        name = (client.get("name") or "").strip()
+        if not name:
+            return "Error: Client name is required for diff preview."
+
+        with self._context.connection() as conn:
+            existing_row = conn.execute(
+                "SELECT * FROM clients WHERE lower(name) = lower(?)",
+                (name,),
+            ).fetchone()
+
+        baseline = _dict_from_row(existing_row) if existing_row else None
+        merged = baseline.copy() if baseline else {"name": name, "parent": None, "phone": None, "email": None, "notes": None}
+
+        for key in ("parent", "phone", "email", "notes"):
+            if key in client and client[key] is not None:
+                merged[key] = _normalize_notes(client[key]) if key == "notes" else client[key]
+
+        if "notes" not in client and baseline:
+            merged["notes"] = baseline.get("notes")
+
+        old_markdown = _render_markdown(baseline) if baseline else ""
+        new_markdown = _render_markdown(merged)
+
+        diff_lines = list(
+            difflib.unified_diff(
+                old_markdown.splitlines(),
+                new_markdown.splitlines(),
+                fromfile="current.md" if existing else "(new client)",
+                tofile="proposed.md",
+                lineterm="",
+            )
+        )
+
+        if not diff_lines:
+            return "No changes detected."
+
+        return "\n".join(diff_lines)
+
+
+class CRMClientApplyUpdate(BaseTool):
+    """Apply a client upsert after review, exporting a markdown snapshot."""
+
+    name: str = "CRM Client Apply Update"
+    description: str = (
+        "Persist approved client updates to the SQLite CRM database. "
+        "Use the same payload reviewed via the diff preview."
+    )
+
+    def __init__(
+        self,
+        db_path: Path | str = DEFAULT_DB_PATH,
+        export_dir: Path | str = DEFAULT_EXPORT_DIR,
+    ) -> None:
+        super().__init__()
+        self._context = _CRMContext(Path(db_path), Path(export_dir))
+
+    def _run(self, client: Dict[str, Any]) -> str:
+        if not isinstance(client, dict):
+            return "Error: 'client' payload must be a dictionary."
+        name = (client.get("name") or "").strip()
+        if not name:
+            return "Error: Client name is required to apply updates."
+
+        with self._context.connection() as conn:
+            existing_row = conn.execute(
+                "SELECT * FROM clients WHERE lower(name) = lower(?)",
+                (name,),
+            ).fetchone()
+
+            baseline = _dict_from_row(existing_row) if existing_row else None
+            record = baseline.copy() if baseline else {"name": name, "parent": None, "phone": None, "email": None, "notes": None}
+
+            for key in ("parent", "phone", "email", "notes"):
+                if key in client and client[key] is not None:
+                    record[key] = _normalize_notes(client[key]) if key == "notes" else client[key]
+
+            if "notes" not in client and baseline:
+                record["notes"] = baseline.get("notes")
+
+            old_markdown = _render_markdown(baseline) if baseline else ""
+            new_markdown = _render_markdown(record)
+
+            if baseline:
+                conn.execute(
+                    """
+                    UPDATE clients
+                    SET parent = :parent,
+                        phone = :phone,
+                        email = :email,
+                        notes = :notes,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = :id
+                    """,
+                    {
+                        "id": baseline["id"],
+                        "parent": record.get("parent"),
+                        "phone": record.get("phone"),
+                        "email": record.get("email"),
+                        "notes": record.get("notes"),
+                    },
+                )
+            else:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO clients (name, parent, phone, email, notes)
+                    VALUES (:name, :parent, :phone, :email, :notes)
+                    """,
+                    {
+                        "name": record["name"],
+                        "parent": record.get("parent"),
+                        "phone": record.get("phone"),
+                        "email": record.get("email"),
+                        "notes": record.get("notes"),
+                    },
+                )
+                record["id"] = cursor.lastrowid
+
+            conn.commit()
+
+        export_path = self._context.export_markdown(record)
+
+        diff_lines = list(
+            difflib.unified_diff(
+                old_markdown.splitlines(),
+                new_markdown.splitlines(),
+                fromfile="current.md" if baseline else "(new client)",
+                tofile="updated.md",
+                lineterm="",
+            )
+        )
+        diff = "\n".join(diff_lines) if diff_lines else "No changes detected."
+
+        return (
+            "Update applied successfully. Markdown snapshot saved to "
+            f"{export_path}.\nDiff:\n{diff}"
+        )
+
+
+class CRMClientListMarkdownExporter(BaseTool):
+    """Export markdown snapshots for all clients."""
+
+    name: str = "CRM Markdown Exporter"
+    description: str = (
+        "Regenerate markdown exports for every client in the database. "
+        "Returns the list of written files."
+    )
+
+    def __init__(
+        self,
+        db_path: Path | str = DEFAULT_DB_PATH,
+        export_dir: Path | str = DEFAULT_EXPORT_DIR,
+    ) -> None:
+        super().__init__()
+        self._context = _CRMContext(Path(db_path), Path(export_dir))
+
+    def _run(self) -> str:
+        written: Iterable[str]
+        with self._context.connection() as conn:
+            rows = conn.execute("SELECT * FROM clients ORDER BY name COLLATE NOCASE").fetchall()
+            paths = []
+            for row in rows:
+                client = _dict_from_row(row)
+                path = self._context.export_markdown(client)
+                paths.append(str(path))
+        written = paths
+        return json.dumps(list(written), ensure_ascii=False, indent=2)
+
+
+__all__ = [
+    "CRMClientReader",
+    "CRMClientDiffPreview",
+    "CRMClientApplyUpdate",
+    "CRMClientListMarkdownExporter",
+]
+


### PR DESCRIPTION
## Summary
- introduce a SQLite-backed CRM toolset that imports legacy markdown, previews diffs, and exports readable markdown snapshots
- update the CRM agent, contextual metadata, and workflow tasks to use the new database tools and require human approval before writes
- refresh example usage so demos and interactive mode point at the SQLite database

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4b68d81f08329b65e4bbd07db78e5